### PR TITLE
:package: (renovate.json) Extend auto update to nix and actions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,14 +1,33 @@
 {
-  "extends": ["config:base"],
-  "enabledManagers": ["gleam"],
-  "schedule": ["every sunday"],
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
   "timezone": "Asia/Tokyo",
-  "automerge": true,
-  "automergeType": "branch",
-  "branchPrefix": "renovate/",
+  "labels": [
+    "dependencies"
+  ],
   "commitMessageAction": "Update",
-  "labels": ["dependencies", "gleam"],
-  "major": {
-    "automerge": false
-  }
+  "automerge": true,
+  "platformAutomerge": true,
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": [
+      "before 5am on monday"
+    ]
+  },
+  "packageRules": [
+    {
+      "matchUpdateTypes": [
+        "minor"
+      ],
+      "minimumReleaseAge": "7 days"
+    },
+    {
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "automerge": false
+    }
+  ]
 }


### PR DESCRIPTION
Drop enabledManagers restriction so flake.lock and GitHub Actions are
updated alongside Gleam deps, switch config:base to config:recommended,
and enable lockFileMaintenance for weekly flake input refresh.

Replace automergeType branch with the default PR mode plus
platformAutomerge so updates land only after CI passes.

Claude-Session: https://claude.ai/code/session_01SBaVErUor1xUPhAPfa5nro
